### PR TITLE
Corrected the previous modification

### DIFF
--- a/examples/playTuneinRadio.js
+++ b/examples/playTuneinRadio.js
@@ -4,8 +4,8 @@ const sonos = new Sonos(process.env.SONOS_HOST || '192.168.2.11')
 // This example demonstrates playing radio staions
 // the Sonos built-in support for tunein radio.
 
-// CAUTION: ID is without leading s
-const stationId = '34682'
+// CAUTION: in older release of node-red the stationId maybe without leading s 
+const stationId = 's34682'
 const stationTitle = '88.5 | Jazz24 (Jazz)'
 
 sonos.playTuneinRadio(stationId, stationTitle).then(success => {


### PR DESCRIPTION
In the current node-sonos release (as of today 2019-08-07) the Id is with leading "s". 
In some older releases - for example the one used by node-red-contrib-better-sonos  - the Id works only without leading "s".